### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/AEITDEV/72a9c077-c000-4b33-a512-8397bc3e430a/fb5854fd-5ca4-4435-b00e-5cd994457c18/_apis/work/boardbadge/3b3fad3e-aa2d-4dbe-a63f-b70179e97149)](https://dev.azure.com/AEITDEV/72a9c077-c000-4b33-a512-8397bc3e430a/_boards/board/t/fb5854fd-5ca4-4435-b00e-5cd994457c18/Microsoft.RequirementCategory)
 ## GitHub Docs <!-- omit in toc -->
 
 This repository contains the documentation website code and Markdown source files for [docs.github.com](https://docs.github.com).


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/AEITDEV/72a9c077-c000-4b33-a512-8397bc3e430a/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.